### PR TITLE
pc - copy backend crud oeprations for team02 for ucsborg table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -1,0 +1,154 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a REST controller for UCSBOrganization
+ */
+
+@Tag(name = "UCSBOrganization")
+@RequestMapping("/api/ucsborganization")
+@RestController
+@Slf4j
+public class UCSBOrganizationController extends ApiController {
+
+    @Autowired
+    UCSBOrganizationRepository ucsbOrganizationRepository;
+
+    /**
+     * List all UCSB Organizations
+     * 
+     * @return an iterable of UCSBOrganization
+     */
+    @Operation(summary = "List all ucsb organizations")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBOrganization> allUCSBOrganization() {
+        Iterable<UCSBOrganization> ucsborganization = ucsbOrganizationRepository.findAll();
+        return ucsborganization;
+    }
+
+    /**
+     * Create a new organization
+     * 
+     * @param orgCode             the ucsb organization code
+     * @param orgTranslationShort the ucsb organization translation short
+     * @param orgTranslation      the ucsb organization translation
+     * @param inactive            inactive boolean
+     * @return the saved ucsborganization
+     */
+    @Operation(summary = "Create a new organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBOrganization postUCSBOrganization(
+            @Parameter(name = "orgCode") @RequestParam String orgCode,
+            @Parameter(name = "orgTranslationShort") @RequestParam String orgTranslationShort,
+            @Parameter(name = "orgTranslation") @RequestParam String orgTranslation,
+            @Parameter(name = "inactive") @RequestParam boolean inactive)
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        // NO TIME CONSTRAINTS FOR UCSB ORGANIZATION
+        // log.info("localDateTime={}", localDateTime);
+
+        UCSBOrganization ucsbOrganization = new UCSBOrganization();
+        ucsbOrganization.setOrgCode(orgCode);
+        ucsbOrganization.setOrgTranslationShort(orgTranslationShort);
+        ucsbOrganization.setOrgTranslation(orgTranslation);
+        ucsbOrganization.setInactive(inactive);
+
+        UCSBOrganization savedUcsbOrganization = ucsbOrganizationRepository.save(ucsbOrganization);
+
+        return savedUcsbOrganization;
+    }
+
+    /**
+     * Get a single ucsborganization by id
+     * 
+     * @param id the id of the ucsb organization
+     * @return a UCSBOrganization
+     */
+    @Operation(summary = "Get a single ucsb Organization")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBOrganization getById(
+            @Parameter(name = "id") @RequestParam Long id) {
+        UCSBOrganization ucsbOrganization = ucsbOrganizationRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, id));
+
+        return ucsbOrganization;
+    }
+
+    /**
+     * Update a single ucsborganization
+     * 
+     * @param id       id of the ucsborganization to update
+     * @param incoming the new ucsborganization
+     * @return the updated ucsborganization object
+     */
+    @Operation(summary = "Update a single ucsborganization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public UCSBOrganization updateUCSBOrganization(
+            @Parameter(name = "id") @RequestParam Long id,
+            @RequestBody @Valid UCSBOrganization incoming) {
+
+        UCSBOrganization ucsbOrganization = ucsbOrganizationRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, id));
+
+        ucsbOrganization.setInactive(incoming.getInactive());
+        ucsbOrganization.setOrgCode(incoming.getOrgCode());
+        ucsbOrganization.setOrgTranslation(incoming.getOrgTranslation());
+        ucsbOrganization.setOrgTranslationShort(incoming.getOrgTranslationShort());
+
+        ucsbOrganizationRepository.save(ucsbOrganization);
+
+        return ucsbOrganization;
+    }
+
+    /**
+     * Delete a UCSBOrganization
+     * 
+     * @param id the id of the ucsborganization to delete
+     * @return a message indicating the ucsborganization was deleted
+     */
+    @Operation(summary = "Delete a UCSBOrganization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteUCSBOrganization(
+            @Parameter(name = "id") @RequestParam Long id) {
+        UCSBOrganization ucsbOrganization = ucsbOrganizationRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, id));
+
+        ucsbOrganizationRepository.delete(ucsbOrganization);
+        return genericMessage("UCSBOrganization with id %s deleted".formatted(id));
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
@@ -1,0 +1,30 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * This is a JPA entity that represents a GitHub commit
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsborganization")
+public class UCSBOrganization {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String orgCode;
+  private String orgTranslationShort;
+  private String orgTranslation;
+  private boolean inactive; //does this need to be private?
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The UCSBOrganizationRepository is a repository for UCSBOrganization entities.
+ */
+
+@Repository
+public interface UCSBOrganizationRepository extends CrudRepository<UCSBOrganization, Long> {
+  
+}

--- a/src/main/resources/db/migration/changes/UCSBOrganization.json
+++ b/src/main/resources/db/migration/changes/UCSBOrganization.json
@@ -1,0 +1,68 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "UCSBOrganization-1",
+          "author": "johnhagedorncs",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "UCSBORGANIZATION"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "UCSBORGANIZATION_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "ORG_CODE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "ORG_TRANSLATION_SHORT",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "ORG_TRANSLATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "INACTIVE",
+                      "type": "BOOLEAN"
+                    }
+                  }
+                ],
+                "tableName": "UCSBORGANIZATION"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -1,0 +1,366 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import org.springframework.http.MediaType; //changed from import com.google.common.net.MediaType;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = UCSBOrganizationController.class)
+@Import(TestConfig.class)
+public class UCSBOrganizationControllerTests extends ControllerTestCase {
+
+    @MockBean
+    UCSBOrganizationRepository ucsbOrganizationRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+        mockMvc.perform(get("/api/ucsborganization/all"))
+                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+        mockMvc.perform(get("/api/ucsborganization/all"))
+                .andExpect(status().is(200));
+    }
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+        mockMvc.perform(post("/api/ucsborganization/post"))
+                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+        mockMvc.perform(post("/api/ucsborganization/post"))
+                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_ucsbdates() throws Exception {
+        // arrange
+        UCSBOrganization org1 = UCSBOrganization.builder()
+                .orgCode("SKY")
+                .orgTranslationShort("Sky Club")
+                .orgTranslation("The Sky is the Limit Club")
+                .inactive(false)
+                .build();
+
+        ArrayList<UCSBOrganization> expectedOrganization = new ArrayList<>();
+        expectedOrganization.add(org1);
+
+        when(ucsbOrganizationRepository.findAll()).thenReturn(expectedOrganization);
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/ucsborganization/all"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(ucsbOrganizationRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedOrganization);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_ucsborganization() throws Exception {
+        // arrange
+        UCSBOrganization org1 = UCSBOrganization.builder()
+                .orgCode("SKY")
+                .orgTranslationShort("Sky Club")
+                .orgTranslation("The Sky is the Limit Club")
+                .inactive(false)
+                .build();
+
+        when(ucsbOrganizationRepository.save(eq(org1))).thenReturn(org1);
+
+        // act
+        MvcResult response = mockMvc.perform(
+                post("/api/ucsborganization/post")
+                        .param("orgCode", "SKY")
+                        .param("orgTranslationShort", "Sky Club")
+                        .param("orgTranslation", "The Sky is the Limit Club")
+                        .param("inactive", "false")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(ucsbOrganizationRepository, times(1)).save(org1);
+        String expectedJson = mapper.writeValueAsString(org1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    // NEW TEST CASE 1: Test getting multiple organizations
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_get_multiple_organizations() throws Exception {
+        // arrange
+        UCSBOrganization org1 = UCSBOrganization.builder()
+                .orgCode("SKY")
+                .orgTranslationShort("Sky Club")
+                .orgTranslation("The Sky is the Limit Club")
+                .inactive(false)
+                .build();
+
+        UCSBOrganization org2 = UCSBOrganization.builder()
+                .orgCode("OCEAN")
+                .orgTranslationShort("Ocean Club")
+                .orgTranslation("Deep Sea Explorers")
+                .inactive(true)
+                .build();
+
+        ArrayList<UCSBOrganization> expectedOrganizations = new ArrayList<>();
+        expectedOrganizations.addAll(Arrays.asList(org1, org2));
+
+        when(ucsbOrganizationRepository.findAll()).thenReturn(expectedOrganizations);
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/ucsborganization/all"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(ucsbOrganizationRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedOrganizations);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    // NEW TEST CASE 2: Test posting organization with inactive status
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_post_inactive_organization() throws Exception {
+        // arrange
+        UCSBOrganization org = UCSBOrganization.builder()
+                .orgCode("INACT")
+                .orgTranslationShort("Inactive Club")
+                .orgTranslation("Currently Inactive Organization")
+                .inactive(true)
+                .build();
+
+        when(ucsbOrganizationRepository.save(eq(org))).thenReturn(org);
+
+        // act
+        MvcResult response = mockMvc.perform(
+                post("/api/ucsborganization/post")
+                        .param("orgCode", "INACT")
+                        .param("orgTranslationShort", "Inactive Club")
+                        .param("orgTranslation", "Currently Inactive Organization")
+                        .param("inactive", "true")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(ucsbOrganizationRepository, times(1)).save(org);
+        String expectedJson = mapper.writeValueAsString(org);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @Test
+    public void logged_out_users_cannot_get_by_id() throws Exception {
+        mockMvc.perform(get("/api/ucsborganization?id=7"))
+                .andExpect(status().is(403)); // logged out users can't get by id
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_does_exist() throws Exception {
+
+        // arrange
+
+        UCSBOrganization org = UCSBOrganization.builder()
+                .orgCode("INACT")
+                .orgTranslationShort("Inactive Club")
+                .orgTranslation("Currently Inactive Organization")
+                .inactive(true)
+                .build();
+
+        when(ucsbOrganizationRepository.findById(eq(7L))).thenReturn(Optional.of(org));
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/ucsborganization?id=7"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(ucsbOrganizationRepository, times(1)).findById(eq(7L));
+        String expectedJson = mapper.writeValueAsString(org);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+        // arrange
+
+        when(ucsbOrganizationRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/ucsborganization?id=7"))
+                .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+
+        verify(ucsbOrganizationRepository, times(1)).findById(eq(7L));
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("EntityNotFoundException", json.get("type"));
+        assertEquals("UCSBOrganization with id 7 not found", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_edit_an_existing_ucsborganization() throws Exception {
+        // arrange
+
+        UCSBOrganization org = UCSBOrganization.builder()
+                .orgCode("INACT")
+                .orgTranslationShort("Inactive Club")
+                .orgTranslation("Currently Inactive Organization")
+                .inactive(true)
+                .build();
+
+        UCSBOrganization editedOrg = UCSBOrganization.builder()
+                .orgCode("NEW-INACT")
+                .orgTranslationShort("New Inactive Club")
+                .orgTranslation("Currently New Inactive Organization")
+                .inactive(false)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(editedOrg);
+
+        when(ucsbOrganizationRepository.findById(eq(67L))).thenReturn(Optional.of(org));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                put("/api/ucsborganization?id=67")
+                        .contentType(MediaType.APPLICATION_JSON) // app_json import included at top
+                        .characterEncoding("utf-8")
+                        .content(requestBody)
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(ucsbOrganizationRepository, times(1)).findById(67L);
+        verify(ucsbOrganizationRepository, times(1)).save(editedOrg);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(requestBody, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_cannot_edit_ucsborganization_that_does_not_exist() throws Exception {
+        // arrange
+
+        UCSBOrganization org = UCSBOrganization.builder()
+                .orgCode("INACT")
+                .orgTranslationShort("Inactive Club")
+                .orgTranslation("Currently Inactive Organization")
+                .inactive(true)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(org);
+
+        when(ucsbOrganizationRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(
+                put("/api/ucsborganization?id=67")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody)
+                        .with(csrf()))
+                .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+        verify(ucsbOrganizationRepository, times(1)).findById(67L);
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("UCSBOrganization with id 67 not found", json.get("message"));
+
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_delete_a_organization() throws Exception {
+        // arrange
+
+        UCSBOrganization org = UCSBOrganization.builder()
+                .orgCode("INACT")
+                .orgTranslationShort("Inactive Club")
+                .orgTranslation("Currently Inactive Organization")
+                .inactive(true)
+                .build();
+
+        when(ucsbOrganizationRepository.findById(eq(15L))).thenReturn(Optional.of(org));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                delete("/api/ucsborganization?id=15")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(ucsbOrganizationRepository, times(1)).findById(15L);
+        verify(ucsbOrganizationRepository, times(1)).delete(eq(org));
+
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("UCSBOrganization with id 15 deleted", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_tries_to_delete_non_existant_ucsborganization_and_gets_right_error_message()
+            throws Exception {
+        // arrange
+
+        when(ucsbOrganizationRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(
+                delete("/api/ucsborganization?id=15")
+                        .with(csrf()))
+                .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+        verify(ucsbOrganizationRepository, times(1)).findById(15L);
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("UCSBOrganization with id 15 not found", json.get("message"));
+    }
+
+}


### PR DESCRIPTION
Closes #17 

In this pr, we copy over the entity repo, controller tests, and db migration file, all backend functionality pretty much, for ucsb organization table, from team01-s25-16.

# To Test

1. Fire up app on localhost or dokku
2. login
3. go to swagger
4. try each of the endpoints in the screenshot below

![image](https://github.com/user-attachments/assets/aa321365-73e5-4e11-8a0d-c7c819c7c492)
