### PR TITLE
cl - Reviews edit page and tests

### DIFF
--- a/frontend/src/main/pages/MenuItemReviews/MenuItemReviewsEditPage.js
+++ b/frontend/src/main/pages/MenuItemReviews/MenuItemReviewsEditPage.js
@@ -1,11 +1,79 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import MenuItemReviewForm from "main/components/MenuItemReviews/MenuItemReviewForm";
+import { Navigate } from "react-router-dom";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function MenuItemReviewsEditPage() {
-  // Stryker disable all : placeholder for future implementation
+export default function MenuItemReviewsEditPage({ storybook = false }) {
+  let { id } = useParams();
+
+  const {
+    data: menuItemReview,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/menuItemReview?id=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/menuitemreviews`,
+      params: {
+        id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (menuItemReview) => ({
+    url: "/api/menuitemreviews",
+    method: "PUT",
+    params: {
+      id: menuItemReview.id,
+    },
+    data: {
+      itemId: menuItemReview.itemId,
+      reviewerEmail: menuItemReview.reviewerEmail,
+      stars: menuItemReview.stars,
+      comments: menuItemReview.comments,
+      dateReviewed: `${menuItemReview.dateReviewed}Z`,
+    },
+  });
+
+  const onSuccess = (menuItemReview) => {
+    toast(
+      `Menu Item Review Updated - id: ${menuItemReview.id} comments: ${menuItemReview.comments}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/menuItemReviews?id=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/menuItemReviews" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit Menu Item Review</h1>
+        {menuItemReview && (
+          <MenuItemReviewForm
+            submitAction={onSubmit}
+            buttonLabel={"Update"}
+            initialContents={menuItemReview}
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewsEditPage.stories.js
+++ b/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewsEditPage.stories.js
@@ -1,0 +1,45 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import MenuItemReviewsEditPage from "main/pages/MenuItemReviews/MenuItemReviewsEditPage";
+import { menuItemReviewsFixtures } from "fixtures/menuItemReviewsFixtures";
+
+export default {
+  title: "pages/MenuItemReviews/MenuItemReviewsEditPage",
+  component: MenuItemReviewsEditPage,
+};
+
+const Template = () => <MenuItemReviewsEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/menuItemReviews", () => {
+      return HttpResponse.json(
+        menuItemReviewsFixtures.threeMenuItemReviews[0],
+        {
+          status: 200,
+        },
+      );
+    }),
+    http.put("/api/menuItemReviews", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+    http.put("/api/menuItemReviews", (req) => {
+      window.alert("PUT: " + req.url + " and body: " + req.body);
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewsEditPage.stories.js
+++ b/frontend/src/stories/pages/MenuItemReviews/MenuItemReviewsEditPage.stories.js
@@ -26,7 +26,7 @@ Default.parameters = {
         status: 200,
       });
     }),
-    http.get("/api/menuItemReviews", () => {
+    http.get("/api/menuitemreviews", () => {
       return HttpResponse.json(
         menuItemReviewsFixtures.threeMenuItemReviews[0],
         {
@@ -34,12 +34,18 @@ Default.parameters = {
         },
       );
     }),
-    http.put("/api/menuItemReviews", () => {
-      return HttpResponse.json({}, { status: 200 });
-    }),
-    http.put("/api/menuItemReviews", (req) => {
-      window.alert("PUT: " + req.url + " and body: " + req.body);
-      return HttpResponse.json({}, { status: 200 });
+    http.put("/api/menuitemreviews", () => {
+      return HttpResponse.json(
+        {
+          id: 17,
+          itemId: 7,
+          reviewerEmail: "james@gmail.com",
+          stars: 1,
+          comments: "bad",
+          dateReviewed: "2025-12-09T10:00:02Z",
+        },
+        { status: 200 },
+      );
     }),
   ],
 };

--- a/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewsEditPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewsEditPage.test.js
@@ -64,7 +64,9 @@ describe("MenuItemReviewsEditPage tests", () => {
         </QueryClientProvider>,
       );
       await screen.findByText("Edit Menu Item Review");
-      expect(screen.queryByTestId("MenuItemReview-comments")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("MenuItemReview-comments"),
+      ).not.toBeInTheDocument();
       restoreConsole();
     });
   });
@@ -82,14 +84,16 @@ describe("MenuItemReviewsEditPage tests", () => {
         .onGet("/api/systemInfo")
         .reply(200, systemInfoFixtures.showingNeither);
       // Fixing the URL to match your component's useBackend URL
-      axiosMock.onGet("/api/menuitemreviews", { params: { id: 17 } }).reply(200, {
-        id: 17,
-        itemId: 6,
-        reviewerEmail: "christianjlee@gmail.com",
-        stars: 3,
-        comments: "really average",
-        dateReviewed: "2025-01-10T10:34:00Z",
-      });
+      axiosMock
+        .onGet("/api/menuitemreviews", { params: { id: 17 } })
+        .reply(200, {
+          id: 17,
+          itemId: 6,
+          reviewerEmail: "christianjlee@gmail.com",
+          stars: 3,
+          comments: "really average",
+          dateReviewed: "2025-01-10T10:34:00Z",
+        });
       axiosMock.onPut("/api/menuitemreviews").reply(200, {
         id: 17,
         itemId: 7,
@@ -97,25 +101,28 @@ describe("MenuItemReviewsEditPage tests", () => {
         stars: 1,
         comments: "bad",
         dateReviewed: "2025-12-09T10:00:02Z",
-      });  
+      });
     });
-  
+
     test("Is populated with the data provided", async () => {
       let capturedPutConfig = null; // capture the PUT request config
-    
+
       // Override the PUT mock to capture config
       axiosMock.onPut("/api/menuitemreviews").reply((config) => {
         capturedPutConfig = config;
-        return [200, {
-          id: 17,
-          itemId: 7,
-          reviewerEmail: "james@gmail.com",
-          stars: 1,
-          comments: "bad",
-          dateReviewed: "2025-12-09T10:00:02Z",
-        }];
+        return [
+          200,
+          {
+            id: 17,
+            itemId: 7,
+            reviewerEmail: "james@gmail.com",
+            stars: 1,
+            comments: "bad",
+            dateReviewed: "2025-12-09T10:00:02Z",
+          },
+        ];
       });
-    
+
       render(
         <QueryClientProvider client={queryClient}>
           <MemoryRouter>
@@ -123,18 +130,18 @@ describe("MenuItemReviewsEditPage tests", () => {
           </MemoryRouter>
         </QueryClientProvider>,
       );
-    
+
       await screen.findByTestId("MenuItemReviewForm-id");
-    
+
       const idField = screen.getByTestId("MenuItemReviewForm-id");
       const itemIdField = screen.getByLabelText("Item Id");
       const reviewerEmailField = screen.getByLabelText("Reviewer Email");
       const starsField = screen.getByLabelText("Stars");
       const commentsField = screen.getByLabelText("Comments");
       const dateReviewedField = screen.getByLabelText("Date Reviewed (in UTC)");
-    
+
       const submitButton = screen.getByText("Update");
-    
+
       expect(idField).toBeInTheDocument();
       expect(idField).toHaveValue(17);
       expect(itemIdField).toHaveValue(6);
@@ -142,22 +149,26 @@ describe("MenuItemReviewsEditPage tests", () => {
       expect(starsField).toHaveValue(3);
       expect(commentsField).toHaveValue("really average");
       expect(dateReviewedField).toHaveValue("2025-01-10T10:34");
-    
+
       fireEvent.change(itemIdField, { target: { value: "7" } });
-      fireEvent.change(reviewerEmailField, { target: { value: "james@gmail.com" } });
+      fireEvent.change(reviewerEmailField, {
+        target: { value: "james@gmail.com" },
+      });
       fireEvent.change(starsField, { target: { value: "1" } });
       fireEvent.change(commentsField, { target: { value: "bad" } });
-      fireEvent.change(dateReviewedField, { target: { value: "2025-12-09T10:00:02" } });
-    
+      fireEvent.change(dateReviewedField, {
+        target: { value: "2025-12-09T10:00:02" },
+      });
+
       fireEvent.click(submitButton);
-    
+
       await waitFor(() => expect(mockToast).toHaveBeenCalled());
-    
+
       expect(mockToast).toHaveBeenCalledWith(
-        "Menu Item Review Updated - id: 17 comments: bad"
+        "Menu Item Review Updated - id: 17 comments: bad",
       );
       expect(mockNavigate).toHaveBeenCalledWith({ to: "/menuItemReviews" });
-    
+
       // Verify the PUT body
       const parsedConfig = JSON.parse(capturedPutConfig.data);
       expect(parsedConfig).toEqual({
@@ -167,7 +178,7 @@ describe("MenuItemReviewsEditPage tests", () => {
         comments: "bad",
         dateReviewed: "2025-12-09T10:00:02.000Z",
       });
-    
+
       // ✅ Mutation-killing line
       expect(capturedPutConfig.params).toEqual({ id: 17 });
     });

--- a/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewsEditPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReviews/MenuItemReviewsEditPage.test.js
@@ -1,43 +1,175 @@
-import { render, screen } from "@testing-library/react";
-import MenuItemReviewsEditPage from "main/pages/MenuItemReviews/MenuItemReviewsEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import MenuItemReviewsEditPage from "main/pages/MenuItemReviews/MenuItemReviewsEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    useParams: () => ({
+      id: 17,
+    }),
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
+});
 
 describe("MenuItemReviewsEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
+  describe("when the backend doesn't return data", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
-    axiosMock.reset();
-    axiosMock.resetHistory();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock
-      .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
-  };
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock.onGet("/api/menuItemReviews", { params: { id: 17 } }).timeout();
+    });
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
+    const queryClient = new QueryClient();
 
-    setupUserOnly();
+    test("renders header but table is not present", async () => {
+      const restoreConsole = mockConsole();
 
-    // act
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <MenuItemReviewsEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <MenuItemReviewsEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText("Edit Menu Item Review");
+      expect(screen.queryByTestId("MenuItemReview-comments")).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
 
-    // assert
-    await screen.findByText("Edit page not yet implemented");
+  describe("tests where backend is working normally", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
+    const queryClient = new QueryClient();
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      // Fixing the URL to match your component's useBackend URL
+      axiosMock.onGet("/api/menuitemreviews", { params: { id: 17 } }).reply(200, {
+        id: 17,
+        itemId: 6,
+        reviewerEmail: "christianjlee@gmail.com",
+        stars: 3,
+        comments: "really average",
+        dateReviewed: "2025-01-10T10:34:00Z",
+      });
+      axiosMock.onPut("/api/menuitemreviews").reply(200, {
+        id: 17,
+        itemId: 7,
+        reviewerEmail: "james@gmail.com",
+        stars: 1,
+        comments: "bad",
+        dateReviewed: "2025-12-09T10:00:02Z",
+      });  
+    });
+  
+    test("Is populated with the data provided", async () => {
+      let capturedPutConfig = null; // capture the PUT request config
+    
+      // Override the PUT mock to capture config
+      axiosMock.onPut("/api/menuitemreviews").reply((config) => {
+        capturedPutConfig = config;
+        return [200, {
+          id: 17,
+          itemId: 7,
+          reviewerEmail: "james@gmail.com",
+          stars: 1,
+          comments: "bad",
+          dateReviewed: "2025-12-09T10:00:02Z",
+        }];
+      });
+    
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <MenuItemReviewsEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+    
+      await screen.findByTestId("MenuItemReviewForm-id");
+    
+      const idField = screen.getByTestId("MenuItemReviewForm-id");
+      const itemIdField = screen.getByLabelText("Item Id");
+      const reviewerEmailField = screen.getByLabelText("Reviewer Email");
+      const starsField = screen.getByLabelText("Stars");
+      const commentsField = screen.getByLabelText("Comments");
+      const dateReviewedField = screen.getByLabelText("Date Reviewed (in UTC)");
+    
+      const submitButton = screen.getByText("Update");
+    
+      expect(idField).toBeInTheDocument();
+      expect(idField).toHaveValue(17);
+      expect(itemIdField).toHaveValue(6);
+      expect(reviewerEmailField).toHaveValue("christianjlee@gmail.com");
+      expect(starsField).toHaveValue(3);
+      expect(commentsField).toHaveValue("really average");
+      expect(dateReviewedField).toHaveValue("2025-01-10T10:34");
+    
+      fireEvent.change(itemIdField, { target: { value: "7" } });
+      fireEvent.change(reviewerEmailField, { target: { value: "james@gmail.com" } });
+      fireEvent.change(starsField, { target: { value: "1" } });
+      fireEvent.change(commentsField, { target: { value: "bad" } });
+      fireEvent.change(dateReviewedField, { target: { value: "2025-12-09T10:00:02" } });
+    
+      fireEvent.click(submitButton);
+    
+      await waitFor(() => expect(mockToast).toHaveBeenCalled());
+    
+      expect(mockToast).toHaveBeenCalledWith(
+        "Menu Item Review Updated - id: 17 comments: bad"
+      );
+      expect(mockNavigate).toHaveBeenCalledWith({ to: "/menuItemReviews" });
+    
+      // Verify the PUT body
+      const parsedConfig = JSON.parse(capturedPutConfig.data);
+      expect(parsedConfig).toEqual({
+        itemId: "7",
+        reviewerEmail: "james@gmail.com",
+        stars: "1",
+        comments: "bad",
+        dateReviewed: "2025-12-09T10:00:02.000Z",
+      });
+    
+      // ✅ Mutation-killing line
+      expect(capturedPutConfig.params).toEqual({ id: 17 });
+    });
   });
 });


### PR DESCRIPTION
Closes #42 

In this PR we replace the placeholder review edit page with a working edit page.

To test: https://team02-dev-applechristian.dokku-16.cs.ucsb.edu/menuItemReviews/edit/1

1. Visit the dokku deployment at 
2. Login
3. Navigate to the menuitemreviews page. If there isn't a review listed there, create one
4. Click the edit button
5. Make changes to each of the fields and click update
6. See that you changes took effect

Storybook: https://team02-dev-applechristian.dokku-16.cs.ucsb.edu

<img width="785" alt="Screenshot 2025-05-10 at 7 42 35 PM" src="https://github.com/user-attachments/assets/53259dc3-ad19-4c8a-a199-407046ef4505" />
